### PR TITLE
Fix python3 invalid dict key iteration during keysize changes

### DIFF
--- a/google_api/drive.py
+++ b/google_api/drive.py
@@ -21,7 +21,8 @@ def to_csv_file(dst_file, rows, credentials=None, new_file=None, finalize=False)
         dst_file['fp'].close()
         local = dst_file['local']
         upload_dest = dst_file['dest']
-        for x in dst_file.keys():
+        dict_keys = dst_file.keys()
+        for x in dict_keys:
             del dst_file[x]
         upload_file(credentials, local, **upload_dest)
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9321688/44181132-a7dbc700-a0c5-11e8-8769-9e39a8e15709.png)

This was fine in python2 because the .keys() method returned an actualized list, in python3 it returns an iterable closure.