### PR TITLE
Fix bogus error

### DIFF
--- a/google_api/sheets.py
+++ b/google_api/sheets.py
@@ -21,8 +21,8 @@ def to_sheet(spreadsheet_id, values, credentials, sheet_name='Sheet1', row_offse
         request.execute()
 
     # Write data to spreadsheet as RAW strings
-    for idx, row in enumerate(values):
-        values[idx] = [str(x) for x in row]
+    for idx in range(len(values)):
+        values[idx] = [str(x) for x in values[idx]]
     request = service.spreadsheets().values().update(
         spreadsheetId=spreadsheet_id,
         range="!".join([sheet_name,ranges]),


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9321688/44183193-aca57880-a0cf-11e8-8ca8-1ea28a802102.png)

While the error message `RuntimeError: dictionary changed size during iteration` looks bogus it makes sense that under the hood in python3 lists and dicts would share some code.

https://github.com/rewardStyle/py-google-api/pull/2 clearly fixed a condition where a dictionary is being modified ( key size changes during iteration )

Looks like iterable list specific functions in python3 do not return actualized lists anymore ( performance improvement on their part )

At the same time, this code never changes the size of the list... so no iteration error should have been thrown.

This message is clearly a bug in python3 but it may be an intentional feature. A way to prevent people from making this pattern in general since the enumerate() and keys() functions no longer return actualized lists.

Throwing an error to prevent mutation of an object's size while an iterable lock has been acquired is a feature that has long been in lua, go, and even latter versions of php.

I was urged to stop trying to actualize iterables in python2 code since they were already actualized. Guess I need to learn to return to old habits in python3 and care about actualization.